### PR TITLE
Corrected RuneMetrics profile skills

### DIFF
--- a/src/utils/Jagex.ts
+++ b/src/utils/Jagex.ts
@@ -99,6 +99,10 @@ export const formatRuneMetricsProfileSkills = (
 ) => {
   const skills = { ...defaultSkillTree }
 
+  // We must offset ID's by one to properly map skills as
+  // RuneMetrics does not provide "overall" in ProfileSkills
+  skillsArray.forEach( (skill)  => { skill.id++ });
+
   hiscores.skills.map((skillName, index) => {
     const { rank, level, xp: experience } = skillsArray.find(
       skill => skill.id === index


### PR DESCRIPTION
### Bug Description
RuneMetrics profile is utilizing the default skill tree of Hiscores. The RuneMetrics API response does not include "overall" skill in in the same branch while Hiscores does. The "overall" skill gets mapped regardless, causing all skills to be offset in the RuneMetrics profile.

### Other Solutions
- Define new types for RuneMetrics skill tree that exclude "overall" skill as it's already part of the RuneMetrics profile
- Pass "overall" skill data into RuneMetrics skill formatting function and unshift with missing "overall" skill information